### PR TITLE
fix(datepicker): replace iOS modal tap-heuristic with Cancel/Done too…

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,12 +473,13 @@ Native date & time picker using **platform system pickers**.
 
 ### iOS Props (`ios`)
 
-| Prop                       | Type                                               | Description                       |
-| -------------------------- | -------------------------------------------------- | --------------------------------- |
-| `preferredStyle`           | `'automatic' \| 'compact' \| 'inline' \| 'wheels'` | iOS date picker style             |
-| `countDownDurationSeconds` | `number`                                           | Duration for countdown timer mode |
-| `minuteInterval`           | `number`                                           | Minute interval (1-30)            |
-| `roundsToMinuteInterval`   | `'inherit' \| 'round' \| 'noRound'`                | Rounding behavior                 |
+| Prop                       | Type                                               | Description                                                              |
+| -------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
+| `preferredStyle`           | `'automatic' \| 'compact' \| 'inline' \| 'wheels'` | iOS date picker style                                                    |
+| `countDownDurationSeconds` | `number`                                           | Duration for countdown timer mode                                        |
+| `minuteInterval`           | `number`                                           | Minute interval (1-30)                                                   |
+| `roundsToMinuteInterval`   | `'inherit' \| 'round' \| 'noRound'`                | Rounding behavior                                                        |
+| `showConfirmToolbar`       | `boolean`                                          | Modal only. Show Cancel/Done toolbar below the picker. Defaults to `true`. See below. |
 
 ### Android Props (`android`)
 
@@ -494,12 +495,14 @@ Native date & time picker using **platform system pickers**.
 
 `onConfirm` fires on every date/time change, but the second argument (`confirmed`) lets you distinguish between browsing and deliberate selections:
 
-| Platform / Mode      | Every change                             | Deliberate selection                                   |
-| -------------------- | ---------------------------------------- | ------------------------------------------------------ |
-| **iOS modal**        | `confirmed: false` (scrolling the wheel) | `confirmed: true` (tapping the already-selected value) |
-| **iOS embedded**     | `confirmed: true`                        | —                                                      |
-| **Android modal**    | —                                        | `confirmed: true` (pressing OK)                        |
-| **Android embedded** | `confirmed: true`                        | —                                                      |
+| Platform / Mode      | Every change                              | Deliberate selection                  |
+| -------------------- | ----------------------------------------- | ------------------------------------- |
+| **iOS modal**        | `confirmed: false` (user still adjusting) | `confirmed: true` (tapping **Done**)  |
+| **iOS embedded**     | `confirmed: true`                         | —                                     |
+| **Android modal**    | —                                         | `confirmed: true` (pressing OK)       |
+| **Android embedded** | `confirmed: true`                         | —                                     |
+
+On iOS in modal presentation, the picker is shown in a popover with a Cancel/Done toolbar below it. Tapping **Done** emits `confirmed: true`; tapping **Cancel** or outside the popover calls `onClosed`. Set `ios.showConfirmToolbar: false` to hide the toolbar — in that mode `confirmed: true` never fires, and your app is expected to drive dismissal by flipping `visible` off (reading the current date from the stream of `confirmed: false` events). This only makes UX sense paired with `ios.preferredStyle: 'inline'`.
 
 A common pattern is to close the modal only on a confirmed selection:
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
-  - PlatformComponents (0.8.6):
+  - PlatformComponents (0.8.8):
     - boost
     - DoubleConversion
     - fast_float
@@ -2733,7 +2733,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 7cbb64ddd1b674c9e68d6dedce1c7adebaa8400e
-  PlatformComponents: c065da87835e941f11d2b4a260e0942e609c7b96
+  PlatformComponents: 6f1a493164d731420949ff276643f03d1112d115
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: a41bbdd9af30bf2e5715796b313e44ec43eefff1
   RCTRequired: 7be34aabb0b77c3cefe644528df0fa0afad4e4d0

--- a/example/src/DatePickerDemo.tsx
+++ b/example/src/DatePickerDemo.tsx
@@ -64,6 +64,8 @@ export function DatePickerDemo(): React.JSX.Element {
     'inherit'
   );
 
+  const [iosConfirmToolbar, setIosConfirmToolbar] = useState(true);
+
   // ----- Android options -----
   const [androidMaterial, setAndroidMaterial] =
     useState<AndroidMaterialMode>('system');
@@ -255,6 +257,17 @@ export function DatePickerDemo(): React.JSX.Element {
               onSelect={(data) => setIosRounds(data as any)}
             />
           </Row>
+
+          <Divider />
+
+          <Row label="Confirm Toolbar">
+            <Switch
+              style={ui.alignEnd}
+              testID="ios-confirm-toolbar-switch"
+              value={iosConfirmToolbar}
+              onValueChange={setIosConfirmToolbar}
+            />
+          </Row>
         </Section>
       )}
 
@@ -346,6 +359,7 @@ export function DatePickerDemo(): React.JSX.Element {
                   ? undefined
                   : Number(iosMinuteInterval),
               roundsToMinuteInterval: iosRounds,
+              showConfirmToolbar: iosConfirmToolbar,
             }}
             android={{
               material: androidMaterial,

--- a/ios/PCDatePicker.mm
+++ b/ios/PCDatePicker.mm
@@ -191,6 +191,14 @@ using namespace facebook::react;
     }
   }
 
+  // Expecting: "show" | "hide"
+  if (oldIos.confirmToolbar != newIos.confirmToolbar) {
+    _datePickerView.confirmToolbarMode =
+        (!newIos.confirmToolbar.empty())
+            ? [NSString stringWithUTF8String:newIos.confirmToolbar.c_str()]
+            : @"show";
+  }
+
   if (needsToUpdateMeasurements) {
     [self updateMeasurements];
   }

--- a/ios/PCDatePickerView.swift
+++ b/ios/PCDatePickerView.swift
@@ -6,15 +6,19 @@ private let logger = Logger(subsystem: "com.platformcomponents", category: "Date
 @objcMembers
 public final class PCDatePickerView: UIControl,
     UIPopoverPresentationControllerDelegate,
-    UIAdaptivePresentationControllerDelegate,
-    UIGestureRecognizerDelegate
+    UIAdaptivePresentationControllerDelegate
 {
     // MARK: - UI
     private let picker = UIDatePicker()
     private var modalVC: UIViewController?
     private var inlineConstraints: [NSLayoutConstraint] = []
-    private var confirmWorkItem: DispatchWorkItem?
-    private var tapGesture: UITapGestureRecognizer?
+
+    private var modalToolbarHeight: CGFloat {
+        // iOS 26 renders bar button items as oversized Liquid Glass pills;
+        // they overflow a standard 44pt toolbar and clip against the popover.
+        if #available(iOS 26.0, *) { return 60 }
+        return 44
+    }
 
     // Suppress "programmatic" valueChanged events (apply props / initial present settle).
     private var suppressChangeEvents = false
@@ -87,6 +91,11 @@ public final class PCDatePickerView: UIControl,
     public var roundsToMinuteIntervalMode: String = "inherit" {
         didSet { if oldValue != roundsToMinuteIntervalMode { applyRoundsMode() } }
     }
+
+    /// "show" | "hide" — modal only. When "hide", the popover has no
+    /// Cancel/Done bar and the caller is responsible for driving dismissal
+    /// via the `visible` prop; valueChanged still emits confirmed=false.
+    public var confirmToolbarMode: String = "show"
 
     // MARK: - Init
 
@@ -199,13 +208,15 @@ public final class PCDatePickerView: UIControl,
             height: max(PCConstants.minTouchTargetHeight, fitted.height))
     }
 
-    /// Separate sizing for popover content.
+    /// Separate sizing for popover content. Accounts for the Cancel/Done
+    /// toolbar that sits below the picker in modal presentation.
     private func popoverContentSize() -> CGSize {
         picker.setNeedsLayout()
         picker.layoutIfNeeded()
 
         let fitted = picker.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        return fitted
+        let extra = confirmToolbarMode == "hide" ? 0 : modalToolbarHeight
+        return CGSize(width: fitted.width, height: fitted.height + extra)
     }
 
     // MARK: - Presentation
@@ -286,17 +297,28 @@ public final class PCDatePickerView: UIControl,
         // Prevent "settle" events right as we present.
         suppressNextChangesBriefly()
 
-        // Set up tap-to-confirm gesture for modal mode
-        confirmWorkItem?.cancel()
-        let tap = UITapGestureRecognizer(target: self, action: #selector(handlePickerTap))
-        tap.cancelsTouchesInView = false
-        tap.delegate = self
-        picker.addGestureRecognizer(tap)
-        tapGesture = tap
-
         let vc = UIViewController()
         picker.translatesAutoresizingMaskIntoConstraints = false
         vc.view.addSubview(picker)
+
+        // Cancel / Done toolbar below the picker — right-justified so both
+        // actions sit in the trailing corner, clear of the calendar header.
+        // Skipped entirely when confirmToolbarMode == "hide".
+        let toolbar: UIToolbar? = confirmToolbarMode == "hide" ? nil : {
+            let t = UIToolbar()
+            t.translatesAutoresizingMaskIntoConstraints = false
+            let flex = UIBarButtonItem(
+                barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let cancelItem = UIBarButtonItem(
+                barButtonSystemItem: .cancel,
+                target: self, action: #selector(handleCancelTap))
+            let doneItem = UIBarButtonItem(
+                barButtonSystemItem: .done,
+                target: self, action: #selector(handleDoneTap))
+            t.items = [flex, cancelItem, doneItem]
+            vc.view.addSubview(t)
+            return t
+        }()
 
         let useInlineFallback: Bool
         if #available(iOS 26.0, *) {
@@ -310,21 +332,42 @@ public final class PCDatePickerView: UIControl,
             vc.view.backgroundColor = .systemBackground
             vc.view.isOpaque = true
 
-            NSLayoutConstraint.activate([
+            var constraints: [NSLayoutConstraint] = [
                 picker.topAnchor.constraint(equalTo: vc.view.topAnchor),
                 picker.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
                 picker.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
-                picker.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
-            ])
+            ]
+            if let toolbar {
+                constraints += [
+                    toolbar.topAnchor.constraint(equalTo: picker.bottomAnchor),
+                    toolbar.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
+                    toolbar.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
+                    toolbar.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
+                    toolbar.heightAnchor.constraint(equalToConstant: modalToolbarHeight),
+                ]
+            } else {
+                constraints.append(
+                    picker.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor))
+            }
+            NSLayoutConstraint.activate(constraints)
         } else {
             // Liquid Glass path
             vc.view.backgroundColor = .clear
             vc.view.isOpaque = false
 
-            NSLayoutConstraint.activate([
+            var constraints: [NSLayoutConstraint] = [
                 picker.topAnchor.constraint(equalTo: vc.view.topAnchor),
                 picker.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
-            ])
+            ]
+            if let toolbar {
+                constraints += [
+                    toolbar.topAnchor.constraint(equalTo: picker.bottomAnchor),
+                    toolbar.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
+                    toolbar.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
+                    toolbar.heightAnchor.constraint(equalToConstant: modalToolbarHeight),
+                ]
+            }
+            NSLayoutConstraint.activate(constraints)
         }
 
         let size = popoverContentSize()
@@ -354,11 +397,6 @@ public final class PCDatePickerView: UIControl,
         guard let vc = modalVC else { return }
         logger.debug("dismissIfNeeded: dismissing modal, emitCancel=\(emitCancel)")
         modalVC = nil
-        confirmWorkItem?.cancel()
-        if let tap = tapGesture {
-            picker.removeGestureRecognizer(tap)
-            tapGesture = nil
-        }
         vc.dismiss(animated: true) { [weak self] in
             guard let self else { return }
             if emitCancel { self.onCancelHandler?() }
@@ -376,11 +414,6 @@ public final class PCDatePickerView: UIControl,
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController)
     {
         modalVC = nil
-        confirmWorkItem?.cancel()
-        if let tap = tapGesture {
-            picker.removeGestureRecognizer(tap)
-            tapGesture = nil
-        }
         onCancelHandler?()
     }
 
@@ -388,21 +421,7 @@ public final class PCDatePickerView: UIControl,
         _ popoverPresentationController: UIPopoverPresentationController
     ) {
         modalVC = nil
-        confirmWorkItem?.cancel()
-        if let tap = tapGesture {
-            picker.removeGestureRecognizer(tap)
-            tapGesture = nil
-        }
         onCancelHandler?()
-    }
-
-    // MARK: - Gesture delegate
-
-    public func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        return gestureRecognizer === tapGesture
     }
 
     // MARK: - Value changes
@@ -412,26 +431,22 @@ public final class PCDatePickerView: UIControl,
         if suppressChangeEvents { return }
 
         let ms = picker.date.timeIntervalSince1970 * 1000.0
+        // In modal mode, valueChanged is "user is still adjusting" —
+        // confirmation only happens when the user taps Done. Embedded
+        // presentation always confirms (there's no Done button to gate on).
         let isModal = presentation == "modal" && modalVC != nil
         onChangeHandler?(NSNumber(value: ms), !isModal)
     }
 
-    @objc private func handlePickerTap() {
+    @objc private func handleDoneTap() {
         guard presentation == "modal", modalVC != nil else { return }
+        let ms = picker.date.timeIntervalSince1970 * 1000.0
+        onChangeHandler?(NSNumber(value: ms), true)
+        dismissIfNeeded(emitCancel: false)
+    }
 
-        confirmWorkItem?.cancel()
-
-        let dateAtTap = picker.date
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self, self.modalVC != nil else { return }
-            // If picker date is still the same, the tap was on the selected row → confirm
-            if self.picker.date == dateAtTap {
-                let ms = dateAtTap.timeIntervalSince1970 * 1000.0
-                self.onChangeHandler?(NSNumber(value: ms), true)
-            }
-        }
-        confirmWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: workItem)
+    @objc private func handleCancelTap() {
+        dismissIfNeeded(emitCancel: true)
     }
 
     // MARK: - Apply props (avoid firing valueChanged)

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -48,6 +48,14 @@ export type DatePickerProps = {
     countDownDurationSeconds?: NativeIOSProps['countDownDurationSeconds'];
     minuteInterval?: NativeIOSProps['minuteInterval'];
     roundsToMinuteInterval?: IOSRoundsToMinuteInterval;
+    /**
+     * Modal only. Show a Cancel/Done toolbar below the picker. Defaults to
+     * true. When false, `onConfirm` never fires with `confirmed: true` —
+     * the caller is expected to drive dismissal themselves by flipping
+     * `visible` off (and can read the current date from the stream of
+     * `confirmed: false` events).
+     */
+    showConfirmToolbar?: boolean;
   };
 
   android?: {
@@ -132,6 +140,7 @@ export function DatePicker(props: DatePickerProps): React.ReactElement {
           countDownDurationSeconds: ios.countDownDurationSeconds,
           minuteInterval: ios.minuteInterval,
           roundsToMinuteInterval: ios.roundsToMinuteInterval,
+          confirmToolbar: ios.showConfirmToolbar === false ? 'hide' : 'show',
         }
       : undefined,
 

--- a/src/DatePickerNativeComponent.ts
+++ b/src/DatePickerNativeComponent.ts
@@ -14,12 +14,14 @@ export type DatePickerPresentation = 'modal' | 'embedded';
 
 export type IOSDatePickerStyle = 'automatic' | 'compact' | 'inline' | 'wheels';
 export type IOSRoundsToMinuteInterval = 'inherit' | 'round' | 'noRound';
+export type IOSConfirmToolbar = 'show' | 'hide';
 
 export type IOSProps = {
   preferredStyle?: string; // IOSDatePickerStyle
   countDownDurationSeconds?: CodegenTypes.Double;
   minuteInterval?: CodegenTypes.Int32;
   roundsToMinuteInterval?: string; // IOSRoundsToMinuteInterval
+  confirmToolbar?: string; // IOSConfirmToolbar
 };
 
 export type AndroidProps = {


### PR DESCRIPTION
The previous "tap that doesn't change the date ⇒ confirm" heuristic misfired on every non-date-changing tap in the inline calendar (month-nav arrows, header, empty space), closing the modal unexpectedly (#3). Replace it with an explicit Cancel/Done toolbar below the picker: Done emits confirmed=true and dismisses; Cancel (and tap-outside) emits onClosed. Works uniformly across wheels, compact, and inline styles. Toolbar height bumps to 60pt on iOS 26+ so the Liquid Glass pill buttons fit.

Also add ios.showConfirmToolbar (default true) to hide the toolbar when the caller wants to drive dismissal via the visible prop; in that mode confirmed=true never fires and the caller reads the current date from the stream of confirmed=false events (only sensible with preferredStyle: 'inline').